### PR TITLE
Update from upstream

### DIFF
--- a/lib/currency.js
+++ b/lib/currency.js
@@ -23,21 +23,29 @@ CurrencyController.prototype.index = function(req, res) {
         self.node.log.error(err);
       }
       if (!err && response.statusCode === 200) {
-        self.binanceRate = parseFloat(JSON.parse(body).price);
+        var data = JSON.parse(body);
+        if (Object.hasOwnProperty.call(data, "price")) {
+            self.binanceRate = parseFloat(data.price);
+        } 
       }
       request('https://www.cryptopia.co.nz/api/GetMarket/4846', function(err, response, body) {
         if (err) {
           self.node.log.error(err);
         }
         if (!err && response.statusCode === 200) {
-          self.cryptopiaRate = parseFloat(JSON.parse(body).Data.LastPrice);
+          var data = JSON.parse(body);
+           if (Object.hasOwnProperty.call(data, "Data")) {
+              if (Object.hasOwnProperty.call(data.Data, "LastPrice")) {
+                   self.cryptopiaRate = parseFloat(data.Data.LastPrice);         
+                   res.jsonp({
+                       status: 200,
+                       data: {
+                         binance: self.binanceRate * self.cryptopiaRate
+                       }
+                  });
+              }                            
+           }
         }
-        res.jsonp({
-          status: 200,
-          data: {
-            binance: self.binanceRate * self.cryptopiaRate
-          }
-        });
       });
     });
   } else {


### PR DESCRIPTION
if you try to read a non existent property, insight reports the error "TypeError: Cannot read property 'Data' of null" and stops